### PR TITLE
fix: panic caused by unhandled command_set length

### DIFF
--- a/src/server/err_handler.zig
+++ b/src/server/err_handler.zig
@@ -11,11 +11,12 @@ const Args = struct {
 
 pub fn build_args(command_set: *const std.ArrayList(ZType)) Args {
     var args: Args = Args{};
-
+    
+    if (command_set.items.len < 1) return args;
     if (command_set.items[0] == .str) args.command = command_set.items[0].str;
-    if (command_set.items.len > 1 and command_set.items[1] == .str) {
-        args.key = command_set.items[1].str;
-    }
+    if (command_set.items.len < 2) return args;
+    if (command_set.items[1] == .str) args.key = command_set.items[1].str;
+
     return args;
 }
 

--- a/src/server/err_handler.zig
+++ b/src/server/err_handler.zig
@@ -11,7 +11,7 @@ const Args = struct {
 
 pub fn build_args(command_set: *const std.ArrayList(ZType)) Args {
     var args: Args = Args{};
-    
+
     if (command_set.items.len < 1) return args;
     if (command_set.items[0] == .str) args.command = command_set.items[0].str;
     if (command_set.items.len < 2) return args;

--- a/src/server/err_handler.zig
+++ b/src/server/err_handler.zig
@@ -11,8 +11,11 @@ const Args = struct {
 
 pub fn build_args(command_set: *const std.ArrayList(ZType)) Args {
     var args: Args = Args{};
+
     if (command_set.items[0] == .str) args.command = command_set.items[0].str;
-    if (command_set.items[1] == .str) args.key = command_set.items[1].str;
+    if (command_set.items.len > 1) {
+        if (command_set.items[1] == .str) args.key = command_set.items[1].str;
+    }
     return args;
 }
 

--- a/src/server/err_handler.zig
+++ b/src/server/err_handler.zig
@@ -13,8 +13,8 @@ pub fn build_args(command_set: *const std.ArrayList(ZType)) Args {
     var args: Args = Args{};
 
     if (command_set.items[0] == .str) args.command = command_set.items[0].str;
-    if (command_set.items.len > 1) {
-        if (command_set.items[1] == .str) args.key = command_set.items[1].str;
+    if (command_set.items.len > 1 and command_set.items[1] == .str) {
+        args.key = command_set.items[1].str;
     }
     return args;
 }

--- a/tests/server/err_handler.zig
+++ b/tests/server/err_handler.zig
@@ -32,7 +32,6 @@ test "UnknownCommand" {
     var expected: []u8 = @constCast("-ERR unknown command\r\n");
 
     try std.testing.expectEqualStrings(expected, stream.getWritten());
-    array.deinit();
 }
 
 test "UnknownCommand with command name" {
@@ -53,7 +52,6 @@ test "UnknownCommand with command name" {
         "-ERR unknown command '{s}'\r\n",
         .{"help"},
     );
-    array.deinit();
 }
 
 test "unexpected error" {
@@ -99,5 +97,4 @@ test "NotFound with key name" {
         "-ERR '{s}' not found\r\n",
         .{"user_cache_12345"},
     );
-    array.deinit();
 }


### PR DESCRIPTION
This pull request adds simple check to ensure `command_set` has a sufficient length before accessing its elements, to avoid panic. Currently, it can be reached by sending an incorrect command, for example: `b'*1\r\n$4\r\nMIAU\r\n'` will cause:
```
error: # server panicked, please check logs in ./log/zcached.log
thread 43216 panic: index out of bounds: index 1, len 1
/home/xxenvy/git/zcached/src/server/err_handler.zig:15:26: 0x3283d6 in build_args (zcached)
    if (command_set.items[1] == .str) args.key = command_set.items[1].str;
                         ^
/home/xxenvy/git/zcached/src/server/request_processor.zig:77:37: 0x31da94 in process (zcached)
        var args = errors.build_args(command_set);
                                    ^
/home/xxenvy/git/zcached/src/server/listener.zig:296:22: 0x31cad0 in handle_request (zcached)
    processor.process(connection);
                     ^
/home/xxenvy/git/zcached/src/server/listener.zig:213:28: 0x3176c2 in handle_connection (zcached)
        self.handle_request(worker, connection) catch |err| {
                           ^
/home/xxenvy/git/zcached/src/server/listener.zig:94:39: 0x3146fe in listen (zcached)
                self.handle_connection(worker, connection);
```