### PR TITLE
feat(command): `LASTSAVE` command to get the last db save timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ for supported types and their encodings, see [types.md](types.md)
 - feat(command): `MSET` and `MGET` for seting and geting multiple keys at once.
 - fix: arrays and maps should be freed after returning to the client.
 - feat(command): `KEYS` command for getting all database keys.
+- fix: panic caused by unhandled command_set length.
+- feat(command): `LASTSAVE` command to get the last db save timestamp.
 
 ### [version 0.0.1] - 11-12-2023
 - feat: first working version.

--- a/commands.md
+++ b/commands.md
@@ -113,3 +113,16 @@ Returns all keys matching in database.
 ```
 KEYS
 ```
+
+### LASTSAVE
+
+**Available since**: 1.0.0\
+**Time complexity**: O(1)
+
+Returns the Unix timestamp of the last successful DB save.
+If there wasn't any successful save, it returns the startup timestamp.
+Because of this, the operation never fails.
+
+```
+LASTSAVE
+```

--- a/src/server/cmd_handler.zig
+++ b/src/server/cmd_handler.zig
@@ -20,6 +20,7 @@ const Commands = enum {
     DBSIZE,
     SAVE,
     KEYS,
+    LASTSAVE,
 };
 pub const CMDHandler = struct {
     allocator: std.mem.Allocator,
@@ -76,6 +77,7 @@ pub const CMDHandler = struct {
             .MGET => return self.mget(command_set.items[1..command_set.items.len]),
             .MSET => return self.mset(command_set.items[1..command_set.items.len]),
             .KEYS => return self.zkeys(),
+            .LASTSAVE => return .{ .ok = .{ .int = self.storage.last_save } },
         };
     }
 
@@ -119,8 +121,7 @@ pub const CMDHandler = struct {
     }
 
     fn save(self: *CMDHandler) HandlerResult {
-        if (self.storage.size() == 0)
-            return .{ .ok = .{ .sstr = @constCast("OK") } };
+        if (self.storage.size() == 0) return .{ .err = error.SaveFailure };
 
         const size = self.storage.save() catch |err| {
             self.logger.log(.Error, "# failed to save data: {?}", .{err});

--- a/src/server/err_handler.zig
+++ b/src/server/err_handler.zig
@@ -36,6 +36,7 @@ pub fn handle(stream: anytype, err: anyerror, args: Args, logger: *const Logger)
         error.MaxClientsReached => try out.writeAll("-ERR max number of clients reached\r\n"),
         error.BulkTooLarge => try out.writeAll("-ERR bulk too large\r\n"),
         error.NotWhitelisted => try out.writeAll("-ERR not whitelisted\r\n"),
+        error.SaveFailure => try out.writeAll("-ERR there is no data to save\r\n"),
         else => try out.writeAll("-ERR unexpected\r\n"),
     };
 }

--- a/src/server/persistance.zig
+++ b/src/server/persistance.zig
@@ -104,6 +104,7 @@ pub fn save(self: *PersistanceHandler, storage: *MemoryStorage) !usize {
     defer self.allocator.free(payload);
 
     try file.writeAll(payload);
+    storage.last_save = timestamp;
 
     return payload.len;
 }
@@ -127,8 +128,6 @@ pub fn load(self: *PersistanceHandler, storage: *MemoryStorage) !void {
 
     var latest_file = latest orelse return error.InvalidFile;
     defer self.allocator.free(latest_file.name);
-
-    // std.debug.print("{s}{s}\n", .{ self.path.?, latest.?.name });
 
     const filename = try std.fmt.allocPrint(
         self.allocator,
@@ -155,6 +154,13 @@ pub fn load(self: *PersistanceHandler, storage: *MemoryStorage) !void {
     const readed_size = try file.read(buffer);
     if (readed_size != latest.?.size) return error.InvalidFile;
     if (!std.mem.eql(u8, buffer[0..4], "zcpf")) return error.InvalidFile;
+    const file_name = latest.?.name;
+
+    const underscore_index: usize = std.mem.indexOf(u8, file_name, "_").?;
+    const dot_index: usize = std.mem.indexOf(u8, file_name, ".").?;
+    const str_timestamp: []const u8 = file_name[underscore_index + 1 .. dot_index];
+
+    storage.last_save = try std.fmt.parseInt(i64, str_timestamp, 10);
 
     var stream = std.io.fixedBufferStream(buffer[4..buffer.len]);
     var reader = stream.reader();

--- a/src/server/storage.zig
+++ b/src/server/storage.zig
@@ -20,6 +20,8 @@ config: Config,
 
 lock: std.Thread.RwLock,
 
+last_save: i64,
+
 pub fn init(
     allocator: std.mem.Allocator,
     config: Config,
@@ -31,6 +33,7 @@ pub fn init(
         .config = config,
         .lock = std.Thread.RwLock{},
         .persister = persister,
+        .last_save = std.time.timestamp(),
     };
 }
 

--- a/tests/server/persistance.zig
+++ b/tests/server/persistance.zig
@@ -11,7 +11,7 @@ const helper = @import("../test_helper.zig");
 
 test "should load" {
     std.fs.cwd().makePath("./tmp/persist") catch {};
-    std.fs.cwd().deleteFile("./tmp/persist/dump_latest.zcpf") catch {};
+    std.fs.cwd().deleteFile("./tmp/persist/dump_123.zcpf") catch {};
 
     var config = try Config.load(std.testing.allocator, null, null);
     defer config.deinit();
@@ -33,7 +33,7 @@ test "should load" {
     try std.testing.expectEqual(storage.internal.count(), 0);
 
     const file_content = "zcpf%4\r\n$5\r\ntest2\r\n$8\r\ntesttest\r\n$5\r\ntest1\r\n$8\r\ntesttest\r\n$5\r\ntest3\r\n$8\r\ntesttest\r\n$5\r\ntest4\r\n$8\r\ntesttest\r\n";
-    const file = try std.fs.cwd().createFile("./tmp/persist/dump_latest.zcpf", .{});
+    const file = try std.fs.cwd().createFile("./tmp/persist/dump_123.zcpf", .{});
     try file.writeAll(file_content);
     defer file.close();
 
@@ -41,7 +41,7 @@ test "should load" {
 
     try std.testing.expectEqual(storage.internal.count(), 4);
 
-    std.fs.cwd().deleteFile("./tmp/persist/dump_latest.zcpf") catch {};
+    std.fs.cwd().deleteFile("./tmp/persist/dump_123.zcpf") catch {};
     std.fs.cwd().deleteDir("./tmp/persist") catch {};
 }
 
@@ -69,13 +69,13 @@ test "should not load without header" {
     try std.testing.expectEqual(storage.internal.count(), 0);
 
     const file_content = "%4\r\n$5\r\ntest2\r\n$8\r\ntesttest\r\n$5\r\ntest1\r\n$8\r\ntesttest\r\n$5\r\ntest3\r\n$8\r\ntesttest\r\n$5\r\ntest4\r\n$8\r\ntesttest";
-    const file = try std.fs.cwd().createFile("./tmp/persist/without_header/dump_latest_invalid.zcpf", .{});
+    const file = try std.fs.cwd().createFile("./tmp/persist/without_header/dump_123.zcpf", .{});
     try file.writeAll(file_content);
     defer file.close();
 
     try std.testing.expectEqual(persister.load(&storage), error.InvalidFile);
 
-    std.fs.cwd().deleteFile("./tmp/persist/without_header/dump_latest_invalid.zcpf") catch {};
+    std.fs.cwd().deleteFile("./tmp/persist/without_header/dump_123.zcpf") catch {};
     std.fs.cwd().deleteDir("./tmp/persist") catch {};
 }
 
@@ -104,13 +104,13 @@ test "should not load invalid ext" {
     try std.testing.expectEqual(storage.internal.count(), 0);
 
     const file_content = "%4\r\n$5\r\ntest2\r\n$8\r\ntesttest\r\n$5\r\ntest1\r\n$8\r\ntesttest\r\n$5\r\ntest3\r\n$8\r\ntesttest\r\n$5\r\ntest4\r\n$8\r\ntesttest";
-    const file = try std.fs.cwd().createFile("./tmp/persist/invalid_ext/dump_latest_invalid.asdf", .{});
+    const file = try std.fs.cwd().createFile("./tmp/persist/invalid_ext/dump_latest_123.asdf", .{});
     try file.writeAll(file_content);
     defer file.close();
 
     try std.testing.expectEqual(persister.load(&storage), error.InvalidFile);
 
-    std.fs.cwd().deleteFile("./tmp/persist/invalid_ext/dump_latest_invalid.asdf") catch {};
+    std.fs.cwd().deleteFile("./tmp/persist/invalid_ext/dump_123.asdf") catch {};
     std.fs.cwd().deleteDir("./tmp/persist") catch {};
 }
 
@@ -139,13 +139,13 @@ test "should not load corrupted file" {
     try std.testing.expectEqual(storage.internal.count(), 0);
 
     const file_content = "%4\r\n$5test2\r\n$4\r\ntesttest\r\n$5\r\ntest1\r\n$8\r\ntesttest\r\n$5\r\ntest3\r\n$8\r\ntesttest\r\n$5\r\ntest4\r\n$8\r\ntesttest";
-    const file = try std.fs.cwd().createFile("./tmp/persist/corrupted/dump_latest_invalid.asdf", .{});
+    const file = try std.fs.cwd().createFile("./tmp/persist/corrupted/dump_123.asdf", .{});
     try file.writeAll(file_content);
     defer file.close();
 
     try std.testing.expectEqual(persister.load(&storage), error.InvalidFile);
 
-    std.fs.cwd().deleteFile("./tmp/persist/corrupted/dump_latest_invalid.asdf") catch {};
+    std.fs.cwd().deleteFile("./tmp/persist/corrupted/dump_123.asdf") catch {};
     std.fs.cwd().deleteDir("./tmp/persist") catch {};
 }
 


### PR DESCRIPTION
In this pull request, we introduce a new command `LASTSAVE` to the server, which returns the Unix timestamp of the last successful save operation. 